### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/The-Software-Compagny/parser_ldap_rfc4512/security/code-scanning/3](https://github.com/The-Software-Compagny/parser_ldap_rfc4512/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow, so it applies to all jobs unless overridden. Since the jobs in this workflow only check out code, install dependencies, run tests, and build the project (and do not need to write to the repository or interact with issues or pull requests), the minimal required permission is `contents: read`. This limits the `GITHUB_TOKEN` to read-only access to repository contents, adhering to the principle of least privilege. The change should be made at the top of `.github/workflows/ci.yml`, after the `name:` key and before the `on:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
