### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/The-Software-Compagny/parser_ldap_rfc4512/security/code-scanning/1](https://github.com/The-Software-Compagny/parser_ldap_rfc4512/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job(s) that limits the GITHUB_TOKEN permissions to the minimum required. In this case, the workflow checks out code, runs tests, builds, and publishes to npm using a secret token, but does not appear to need write access to repository contents or other resources via GITHUB_TOKEN. Therefore, the minimal starting point is to set `contents: read` at the workflow or job level. This can be done by adding the following block after the workflow name and before the `on:` block, or inside the `publish` job. The best practice is to set it at the workflow level so all jobs inherit it unless overridden.

Edit `.github/workflows/publish.yml` to add:

```yaml
permissions:
  contents: read
```

immediately after the `name: Publish` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
